### PR TITLE
remove calls to undefined App::Sandy::Types->import

### DIFF
--- a/lib/App/Sandy/Base.pm
+++ b/lib/App/Sandy/Base.pm
@@ -85,7 +85,6 @@ sub import {
 			Moose->import({into=>$caller});
 			MooseX::StrictConstructor->import({into=>$caller});
 			MooseX::UndefTolerant->import({into=>$caller});
-			App::Sandy::Types->import({into=>$caller});
 			after_runtime {
 				$caller->meta->make_immutable;
 			}
@@ -93,7 +92,6 @@ sub import {
 			require Moose::Role;
 			require App::Sandy::Types;
 			Moose::Role->import({into=>$caller});
-			App::Sandy::Types->import({into=>$caller});
 		} elsif ($opt eq 'test') {
 			use_module('Test::Most')->import::into($caller);
 			if ($opt_args) {


### PR DESCRIPTION
App::Sandy::Types does not export anything, and has no import method. The calls to its import method were ignored by perl. Future versions of perl are intending to throw errors for calls to an undefined import method that includes arguments.